### PR TITLE
Update in pose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 AnimExtras is an addon for Blender that adds ease-of-use for animators using onion skinning. It will allow animators to preview have 3d onion skinning in the 3D View using different preview modes. Colors are fully customizable, together with the opacity. Added options allow for a convenient preview when viewing the onion skinning.
 
+NOTE OF THIS FORK: NOW WORKING ON BLENDER 4.4.3!!!
+
 !['Preview'](https://raw.githubusercontent.com/wiki/schroef/animextras/images/anmx-v112.jpg?2021-04-21.2)
 
 ## Features
@@ -26,8 +28,8 @@ AnimExtras is an addon for Blender that adds ease-of-use for animators using oni
 
 | **OS** | **Blender** |
 | ------------- | ------------- |
-| OSX | Blender 2.80 |
-| Windows | Blender 2.80 |
+| OSX | Blender 4.4.3 |
+| Windows | Blender 4.4.3 |
 | Linux | Not Tested |
 
 <!-- ### Blender 2.80 | Pre-release

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ NOTE OF THIS FORK: UPDATED FOR 2025 - NOW WORKING ON BLENDER 4.4.3!!!
 
 * Dedicated panel
 * Easy clear / update skinning
+* Added support for multiple meshes, helpfull for animating proxy rigs.
 * 4 preview modes
   * Per-Frame
   * Per-Frame Stepped

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ AnimExtras is an addon for Blender that adds ease-of-use for animators using oni
 
 NOTE OF THIS FORK: UPDATED FOR 2025 - NOW WORKING ON BLENDER 4.4.3!!!
 
+Remember, this addon calculates the skinning for all frames in the playback range that you have in Blender, to change that you'll have to set your start and end in the Timeline Editor.
+
+This add-on doesn't auto update with changes in animation yet, adapt your workflow so you update your onion skin everytime you make a change.
+
+Happy Animating!
+
 !['Preview'](https://raw.githubusercontent.com/wiki/schroef/animextras/images/anmx-v112.jpg?2021-04-21.2)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 AnimExtras is an addon for Blender that adds ease-of-use for animators using onion skinning. It will allow animators to preview have 3d onion skinning in the 3D View using different preview modes. Colors are fully customizable, together with the opacity. Added options allow for a convenient preview when viewing the onion skinning.
 
-NOTE OF THIS FORK: NOW WORKING ON BLENDER 4.4.3!!!
+NOTE OF THIS FORK: UPDATED FOR 2025 - NOW WORKING ON BLENDER 4.4.3!!!
 
 !['Preview'](https://raw.githubusercontent.com/wiki/schroef/animextras/images/anmx-v112.jpg?2021-04-21.2)
 

--- a/__init__.py
+++ b/__init__.py
@@ -24,9 +24,9 @@
 
 bl_info = {
     "name": "AnimExtras",
-    "author": "Andrew Combs, Rombout Versluijs",
-    "version": (1, 1, 2),
-    "blender": (2, 80, 0),
+    "author": "Andrew Combs, Rombout Versluijs, Sebastian Sarmiento",
+    "version": (1, 1, 3),
+    "blender": (4, 4, 3),
     "description": "True onion skinning",
     "category": "Animation",
     "wiki_url": "https://github.com/iBrushC/animextras",

--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@
 bl_info = {
     "name": "AnimExtras",
     "author": "Andrew Combs, Rombout Versluijs, Sebastian Sarmiento",
-    "version": (1, 1, 5),
+    "version": (1, 1, 6),
     "blender": (4, 4, 3),
     "description": "True onion skinning",
     "category": "Animation",

--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@
 bl_info = {
     "name": "AnimExtras",
     "author": "Andrew Combs, Rombout Versluijs, Sebastian Sarmiento",
-    "version": (1, 1, 4),
+    "version": (1, 1, 5),
     "blender": (4, 4, 3),
     "description": "True onion skinning",
     "category": "Animation",

--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@
 bl_info = {
     "name": "AnimExtras",
     "author": "Andrew Combs, Rombout Versluijs, Sebastian Sarmiento",
-    "version": (1, 1, 3),
+    "version": (1, 1, 4),
     "blender": (4, 4, 3),
     "description": "True onion skinning",
     "category": "Animation",

--- a/ons/gui.py
+++ b/ons/gui.py
@@ -18,13 +18,22 @@ class ANMX_gui(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         access = context.scene.anmx_data
-        # obj = context.object
-        obj = context.active_object
 
-        # Makes UI split like 2.8 no split factor 0.3 needed
         layout.use_property_split = True
         layout.use_property_decorate = False
-        
+
+        # Show onion group or prompt to set
+        if not access.onion_group:
+            layout.operator("anim_extras.set_onion", text="Set Onion Group")
+            layout.label(text="Select mesh objects and click 'Set Onion Group'", icon='INFO')
+            return
+
+        # Show current group
+        box = layout.box()
+        box.label(text="Onion Group:")
+        for item in access.onion_group:
+            box.label(text=item.name, icon='OUTLINER_OB_MESH')
+
         # Makes sure the user can't do any operations when the onion object doesn't exist
         if access.onion_object not in bpy.data.objects:
             layout.operator("anim_extras.set_onion")
@@ -106,4 +115,3 @@ class ANMX_gui(bpy.types.Panel):
             text = "Stop Drawing"
         icoOni = 'ONIONSKIN_OFF' if access.toggle else 'ONIONSKIN_ON'
         layout.prop(access, "toggle", text=text, toggle=True, icon=icoOni)
-        

--- a/ons/gui.py
+++ b/ons/gui.py
@@ -18,24 +18,15 @@ class ANMX_gui(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         access = context.scene.anmx_data
+        # obj = context.object
+        obj = context.active_object
 
+        # Makes UI split like 2.8 no split factor 0.3 needed
         layout.use_property_split = True
         layout.use_property_decorate = False
-
-        # Show onion group or prompt to set
-        if not access.onion_group:
-            layout.operator("anim_extras.set_onion", text="Set Onion Group")
-            layout.label(text="Select mesh objects and click 'Set Onion Group'", icon='INFO')
-            return
-
-        # Show current group
-        box = layout.box()
-        box.label(text="Onion Group:")
-        for item in access.onion_group:
-            box.label(text=item.name, icon='OUTLINER_OB_MESH')
-
+        
         # Makes sure the user can't do any operations when the onion object doesn't exist
-        if access.onion_object not in bpy.data.objects:
+        if not access.onion_group or len(access.onion_group) == 0:
             layout.operator("anim_extras.set_onion")
             return
         if context.selected_objects == []:
@@ -51,8 +42,10 @@ class ANMX_gui(bpy.types.Panel):
             layout.separator(factor=0.2)
         
         
-        col = layout.column()
-        col.prop(access,"onion_object", text="Current", emboss=False, icon='OUTLINER_OB_MESH') #text="{}".format(access.onion_object), 
+        box = layout.box()
+        box.label(text="Onion Group:")
+        for item in access.onion_group:
+            box.label(text=item.name, icon='OUTLINER_OB_MESH')
         
         col = layout.column()
         col.prop(access, "onion_mode", text="Method")

--- a/ons/ops.py
+++ b/ons/ops.py
@@ -316,7 +316,38 @@ class ANMX_update_onion(Operator):
             return {'CANCELLED'}
 
         # Update the onion skinning data for the group
+        # Save current mode and selection
+        prev_mode = context.mode
+        prev_selected = [obj for obj in context.selected_objects]
+        prev_active = context.view_layer.objects.active
+
+        # Switch to Object mode
+        if prev_mode != 'OBJECT':
+            bpy.ops.object.mode_set(mode='OBJECT')
+
+        # Select all objects in the onion group
+        anmx = context.scene.anmx_data
+        group_objs = anmx.get_onion_group()
+        bpy.ops.object.select_all(action='DESELECT')
+        for obj in group_objs:
+            obj.select_set(True)
+        if group_objs:
+            context.view_layer.objects.active = group_objs[0]
+
+        # Run the update logic
         set_to_active()
+
+        # Restore previous selection
+        bpy.ops.object.select_all(action='DESELECT')
+        for obj in prev_selected:
+            obj.select_set(True)
+        if prev_active:
+            context.view_layer.objects.active = prev_active
+
+        # Restore previous mode
+        if prev_mode != 'OBJECT':
+            bpy.ops.object.mode_set(mode=prev_mode)
+
         return {"FINISHED"}
 
 # Uses a list formatted in the following way to draw the meshes:

--- a/ons/ops.py
+++ b/ons/ops.py
@@ -451,23 +451,16 @@ class ANMX_draw_meshes(Operator):
     bl_label = "Draw"
     bl_description = "Draws a set of meshes without creating objects"
     bl_options = {'REGISTER', 'UNDO' }
-    
-    def __init__(self):
-        print("#### __INIT__ DRAW MESHES ####")
-        self.handler = None
-        self.timer = None
-        self.mode = None
-    
-    def __del__(self):
-        """ unregister when done, helps when reopening other scenes """
-        print("#### UNREGISTER HANDLERS ####")
-        self.finish(bpy.context)
-        print("#### HANDLER %s ####" % self.handler)
+
+    def execute(self, context):
+        return {'FINISHED'}
 
     def invoke(self, context, event):
+        self.handler = None
+        self.timer = None
+        self.mode = context.scene.anmx_data.onion_mode
         self.register_handlers(context)
         context.window_manager.modal_handler_add(self)
-        self.mode = context.scene.anmx_data.onion_mode
         return {'RUNNING_MODAL'}
 
     def register_handlers(self, context):

--- a/ons/ops.py
+++ b/ons/ops.py
@@ -310,11 +310,6 @@ class ANMX_update_onion(Operator):
     bl_options = {'REGISTER', 'UNDO' }
     
     def execute(self, context):
-        # Extra check for the shortcuts
-        if not check_selected(context):
-            self.report({'INFO'}, "Onion needs active selection")
-            return {'CANCELLED'}
-
         # Update the onion skinning data for the group
         # Save current mode and selection
         prev_mode = context.mode


### PR DESCRIPTION
So, as this addon was not working in the most recent version of Blender (4.4.3), I decided to update it, which ended up well, but then I decided to add some features, the main one being to be abled to generate onion skining to groups of meshes instead of a single one. I did that by changing the workflow: grabbing the selected meshes, filtering them, and then creating a list called onion_group. This group is maintained as a base for the whole operation. To onion skin this group, I made a function that grabs the group and bakes a big mesh in a similar way that it was done in the original, but this is done for each stage. From there, I changed the whole logic to work with onion_group instead of a single object. The onion skin is then applied correctly (even if the objects are linked or not) with my join mesh function. The rest remains pretty much the same. This is great for working with proxy rigs, and these are rigs composed of different parts of the mesh that are constrained into the rig for bone by bone, instead of a single mesh being controlled through a modifier. The addon now calculates the onion skin in a range given by the playback start and end in Blender. 
![image](https://github.com/user-attachments/assets/e120b888-a329-4533-8fe0-3a8006a8da8c)
